### PR TITLE
Test: disable hardware AEC and noise supressor

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -110,13 +110,10 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             }
         }
 
-        if (adm == null) {
-            // Related issue: https://github.com/react-native-webrtc/react-native-webrtc/issues/713
-            adm = JavaAudioDeviceModule.builder(reactContext)
-                    .setUseHardwareAcousticEchoCanceler(false)
-                    .setUseHardwareNoiseSuppressor(false)
-                    .createAudioDeviceModule();
-        }
+        // Related issue: https://github.com/react-native-webrtc/react-native-webrtc/issues/713
+        adm = JavaAudioDeviceModule.builder(reactContext)
+                .setUseHardwareAcousticEchoCanceler(false)
+                .createAudioDeviceModule();
 
         mFactory
             = PeerConnectionFactory.builder()

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -111,7 +111,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
 
         if (adm == null) {
-            // adm = JavaAudioDeviceModule.builder(reactContext).createAudioDeviceModule();
+            // Related issue: https://github.com/react-native-webrtc/react-native-webrtc/issues/713
             adm = JavaAudioDeviceModule.builder(reactContext)
                     .setUseHardwareAcousticEchoCanceler(false)
                     .setUseHardwareNoiseSuppressor(false)

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -111,7 +111,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
 
         if (adm == null) {
-            adm = JavaAudioDeviceModule.builder(reactContext).createAudioDeviceModule();
+            // adm = JavaAudioDeviceModule.builder(reactContext).createAudioDeviceModule();
+            adm = JavaAudioDeviceModule.builder(reactContext)
+                    .setUseHardwareAcousticEchoCanceler(false)
+                    .setUseHardwareNoiseSuppressor(false)
+                    .createAudioDeviceModule();
         }
 
         mFactory


### PR DESCRIPTION
> [...] it became clear that hardware based acoustic echo cancellation is broken on many combinations of HW + OS versions and while there were white and black lists in webrtc to control what devices should or should not use hardware AEC the only simple and reliable solution is to disable hardware AEC and rely on one that comes with webrtc.

영상통화 중 자신의 목소리가 echo되어 들리는 버그를 고치기 위한 수정. HW AEC/NS 대신 WebRTC AEC를 사용했을 때 성능적으로 얼마나 차이가 있는지 반드시 확인해봐야 함

재현 가능한 기기: galaxy note 10